### PR TITLE
Add bulk resident hide/show functionality to admin

### DIFF
--- a/bone/boneweb/admin.py
+++ b/bone/boneweb/admin.py
@@ -1,7 +1,16 @@
 from django.contrib import admin
 from .models import Resident
 
+def make_hidden(modeladmin, request, queryset):
+    queryset.update(visible=False)
+make_hidden.short_description = "Hide selected residents"
+
+def make_visible(modeladmin, request, queryset):
+    queryset.update(visible=True)
+make_visible.short_description = "Show selected residents"
+
 class ResidentAdmin(admin.ModelAdmin):
     list_display = ('name', 'kerberos', 'bio', 'visible')
+    actions = [make_hidden, make_visible]
 
 admin.site.register(Resident, ResidentAdmin)


### PR DESCRIPTION
Allows admin to hide/show users in bulk.
<img width="308" alt="" src="https://cloud.githubusercontent.com/assets/5657068/17176468/e0f09ca8-53da-11e6-94de-71a590365303.png">
