### PR TITLE
Add caching for residents page

### DIFF
--- a/bone/boneweb/templates/boneweb/residents.html
+++ b/bone/boneweb/templates/boneweb/residents.html
@@ -1,6 +1,8 @@
 {% extends "boneweb/simple.html" %}
 {% load thumbnail %}
+{% load cache %}
 {% block content %}
+{% cache 60 residents year %}
 <h1>Residents<!--{% if year %} - {{ year }}{% endif %}--></h1>
 <ul class="nav nav-tabs nav-justified resident-year-nav">
   <li role="presentation" {% if not year %}class="active"{% endif %}><a href="{% url 'residents' %}">All</a></li>
@@ -23,4 +25,5 @@
   </div>
 </div>
 {% endfor %}
+{% endcache %}
 {% endblock %}


### PR DESCRIPTION
Without caching:

```
ab -n 1000 http://192.168.99.100:8000/residents/

Concurrency Level:      1
Time taken for tests:   41.450 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      14839000 bytes
HTML transferred:       14662000 bytes
Requests per second:    24.13 [#/sec] (mean)
Time per request:       41.450 [ms] (mean)
Time per request:       41.450 [ms] (mean, across all concurrent requests)
Transfer rate:          349.60 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       1
Processing:    37   41   4.7     40      82
Waiting:       34   38   4.2     37      74
Total:         37   41   4.7     40      82

Percentage of the requests served within a certain time (ms)
  50%     40
  66%     41
  75%     42
  80%     42
  90%     45
  95%     52
  98%     58
  99%     61
 100%     82 (longest request)
```

With Caching:

```
ab -n 1000 http://192.168.99.100:8000/residents/

Concurrency Level:      1
Time taken for tests:   12.225 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      14841000 bytes
HTML transferred:       14664000 bytes
Requests per second:    81.80 [#/sec] (mean)
Time per request:       12.225 [ms] (mean)
Time per request:       12.225 [ms] (mean, across all concurrent requests)
Transfer rate:          1185.50 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       1
Processing:     9   12   2.8     11      43
Waiting:        8   11   2.6     11      41
Total:          9   12   2.8     12      44

Percentage of the requests served within a certain time (ms)
  50%     12
  66%     12
  75%     12
  80%     12
  90%     13
  95%     16
  98%     21
  99%     24
 100%     44 (longest request)
```
