### PR TITLE
Fix Alumni Class Page Views

### DIFF
--- a/bone/boneweb/tests.py
+++ b/bone/boneweb/tests.py
@@ -79,7 +79,7 @@ class ResidentsPageTestCase(TestCase):
         self.assertNotIn(b'Patrick', r.content)
         self.assertNotIn(b'Abhi', r.content)
         self.assertNotIn(b'Shader', r.content)
-        self.assertIn(b'Anubhav', r.content)
+        self.assertNotIn(b'Anubhav', r.content)
     def test_alumni_page(self):
         r = self.c.get('/residents/alumni/')
         self.assertEqual(200, r.status_code)

--- a/bone/boneweb/tests.py
+++ b/bone/boneweb/tests.py
@@ -75,11 +75,7 @@ class ResidentsPageTestCase(TestCase):
         self.assertNotIn(b'Anubhav', r.content)
     def test_2016_page(self):
         r = self.c.get('/residents/2016/')
-        self.assertEqual(200, r.status_code)
-        self.assertNotIn(b'Patrick', r.content)
-        self.assertNotIn(b'Abhi', r.content)
-        self.assertNotIn(b'Shader', r.content)
-        self.assertNotIn(b'Anubhav', r.content)
+        self.assertEqual(404, r.status_code)
     def test_alumni_page(self):
         r = self.c.get('/residents/alumni/')
         self.assertEqual(200, r.status_code)

--- a/bone/boneweb/views.py
+++ b/bone/boneweb/views.py
@@ -26,7 +26,7 @@ def residents(request):
 
 def residents_by_year(request, year):
     all_years = Resident.objects.filter(visible=True, alumni=False).values_list('year', flat=True).distinct().order_by('year')
-    visible_residents = Resident.objects.filter(visible=True, year=year).order_by('name')
+    visible_residents = Resident.objects.filter(visible=True, year=year, alumni=False).order_by('name')
     if visible_residents.count() == 0:
         raise Http404()
     visible_alums = Resident.objects.filter(visible=True, alumni=True)


### PR DESCRIPTION
Before people who had graduated already would show up under their class. This is no longer the case.